### PR TITLE
Use -9999 as nodata value

### DIFF
--- a/src/densitycheck/density.py
+++ b/src/densitycheck/density.py
@@ -4,6 +4,8 @@ from osgeo import gdal, osr
 gdal.UseExceptions()
 osr.UseExceptions()
 
+NODATA_VALUE = -9999
+
 def get_density(las_data, cell_size):
     input_points = las_data.points
 
@@ -59,7 +61,7 @@ def get_density(las_data, cell_size):
     dataset.SetGeoTransform(raster_geotransform)
     dataset.SetProjection(output_spatialreference.ExportToWkt())
     band = dataset.GetRasterBand(1)
-    band.SetNoDataValue(0)
+    band.SetNoDataValue(NODATA_VALUE)
     band.WriteArray(cell_densities)
 
     return dataset

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -1,7 +1,7 @@
 from osgeo import osr
 import numpy as np
 
-from densitycheck.density import get_density
+from densitycheck.density import get_density, NODATA_VALUE
 
 osr.UseExceptions()
 
@@ -17,5 +17,5 @@ def test_get_density(las_data, osr_spatialreference):
     assert output_srs.IsSame(osr_spatialreference)
     np.testing.assert_allclose(output_geotransform, [600000.0, 500.0, 0.0, 6201000.0, 0.0, -500.0])
     assert (dataset.RasterXSize, dataset.RasterYSize) == (2, 2)
-    assert output_nodata_value == 0
+    assert output_nodata_value == NODATA_VALUE
     np.testing.assert_allclose(output_array, [[4e-6, 8e-6], [0, 4e-6]])


### PR DESCRIPTION
Using 0 as nodata may mask problematic areas with insufficient points. It is probably better to only use nodata in areas that are masked out (not yet implemented).