### PR TITLE
Remove stdout encoding reconfiguration

### DIFF
--- a/src/densitycheck/cli.py
+++ b/src/densitycheck/cli.py
@@ -10,9 +10,6 @@ import json
 from pathlib import Path
 import sys
 
-# UTF-8 (for box-drawing characters) doesn't seem too reliable on Windows otherwise
-sys.stdout.reconfigure(encoding='utf-8')
-
 gdal.UseExceptions()
 ogr.UseExceptions()
 


### PR DESCRIPTION
With #20 merged, it is no longer relevant to enforce UTF-8 encoding on stdout.